### PR TITLE
optee-os: Fix missing CUBEMX_BOARD_DDR_SIZE_option

### DIFF
--- a/recipes-security/optee/optee-os-stm32mp_%.bbappend
+++ b/recipes-security/optee/optee-os-stm32mp_%.bbappend
@@ -15,6 +15,11 @@ python () {
 }
 
 # manage paramater value
+# Memory size
+CUBEMX_BOARD_DDR_SIZE_option = "\
+    ${@'CFG_DRAM_SIZE=${CUBEMX_BOARD_DDR_SIZE_HEXA}' if (d.getVar('CUBEMX_BOARD_DDR_SIZE_HEXA') != '') else '' } \
+    "
+
 # DVFS OFF
 CUBEMX_SOC_DVFS_OFF_option = "\
     ${@bb.utils.contains('CUBEMX_SOC_DVFS_OFF', '1', 'CFG_STM32MP1_CPU_OPP=n FG_SCMI_MSG_PERF_DOMAIN=n', '', d)} \


### PR DESCRIPTION
Reintroduce the CUBEMX_BOARD_DDR_SIZE_option variable, which was removed between the last release and this one. This variable is required to set the CFG_DRAM_SIZE build option correctly.